### PR TITLE
Refactor message response handlers into functions

### DIFF
--- a/WoWBingoBot.py
+++ b/WoWBingoBot.py
@@ -10,24 +10,39 @@ bingo = WowBingo()
 async def on_message(message):
     if message.author == client.user:
         return
-    """ There's a space in the keyword commands to ensure future related commands.
-    i.e. ?bingo-save, ?bingo-cone """
-    if message.content.startswith('?bingo '):
 
-        msg = 'Hello {0.author.mention}'.format(message)
+    command = message.content.split()[0]
 
-        if message.author.name == 'LinaeSostra' :
-            msg = 'Here\'s your bingo card you trash panda {0.author.mention}'.format(message)
-        elif message.author.name == 'Netflixnheal':
-            msg = 'Here you go master: '
+    handler = {
+        "?bingo": bingo_handler,
+        "?about": about_handler
+    }.get(command, noop_handler)
 
-        await client.send_message(message.channel, msg)
-        await client.send_file(message.channel, bingo.generate_board(message.author.name))
+    await handler(message)
 
-    elif message.content.startswith('?about '):
-        msg = 'Bingo bot for dank memes...by Dan'
-        await client.send_message(message.channel, msg)
+    return
 
+async def bingo_handler(message):
+    msg = 'Hello {0.author.mention}'.format(message)
+
+    if message.author.name == 'LinaeSostra' :
+        msg = 'Here\'s your bingo card you trash panda {0.author.mention}'.format(message)
+    elif message.author.name == 'Netflixnheal':
+        msg = 'Here you go master: '
+
+    await client.send_message(message.channel, msg)
+    await client.send_file(message.channel, bingo.generate_board(message.author.name))
+
+    return
+
+async def about_handler(message):
+    msg = 'Bingo bot for dank memes...by Dan'
+    await client.send_message(message.channel, msg)
+
+    return
+
+async def noop_handler(message):
+    pass
 
 @client.event
 async def on_ready():


### PR DESCRIPTION
### Commit
We separate out the individual message reactions into three handlers, one for
each of the current possible reactions: generate a bingo card, print the about
information, or do nothing. We also dispatch to these handlers using a bit more
sane dictionary-dispatch approach.

### Testing
`python3.5 BingoTest.py` produced an output image.

Bot ran on a test discord server. Responded appropriately to `?bingo`, `?about`, and did not react to `?bingo2`, `?notacommand`, or `Give me a ?bingo`. When given `?bingo argument`, it just created a bingo board.